### PR TITLE
npm run test:unit:debugコマンドを実行するとJestでChromeデバッガーを利用出来るようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint --ext .js,.ts,.vue --ignore-path .gitignore .",
     "lint-fix": "eslint --fix --ext .js,.ts,.vue --ignore-path .gitignore .",
     "test": "jest",
+    "test:unit:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --no-cache --runInBand",
     "json": "json-server -p 3001 --watch db.json"
   },
   "dependencies": {


### PR DESCRIPTION
## 背景

console.logのプリントデバッグだとテストコードのデバッグしんどいので、Chromeデバッガーを利用出来るようにしたい

## やったこと

- [x] JestでChromeデバッガーを利用出来るようにNode.jsがWebsocketをリッスンするようにした

## 確認方法

- `npm run test:unit:debug` を実行
- 上記コマンドを起動した状態でChromeを開き、開発者コンソールの以下の部分をクリックし、デバッグ用ウィンドウを開く

![スクリーンショット_2021-03-27_23_03_23](https://user-images.githubusercontent.com/27620649/112723255-ed84ef80-8f50-11eb-9987-addd7b2af697.png)
