### PR TITLE
Issue詳細のbodyのテキストに white-spece: pre-line を入れることで改行反映して読みやすくなるよう修正

### DIFF
--- a/pages/issues/_number.vue
+++ b/pages/issues/_number.vue
@@ -15,7 +15,7 @@
           {{ issue.title }}
           <span class="font-light text-gray-500">#{{ issue.number }}</span>
         </h1>
-        <p class="mt-8">
+        <p class="mt-8 whitespace-pre-line">
           {{ issue.body }}
         </p>
       </template>


### PR DESCRIPTION
## やったこと

- Issue詳細のテキストを改行反映して読みやすい形式に修正#17 

## 修正前キャプチャ

![image](https://user-images.githubusercontent.com/27620649/113875447-b684c880-97f1-11eb-8243-127c2f772a82.png)


## 修正後キャプチャ

![image](https://user-images.githubusercontent.com/27620649/113875312-96550980-97f1-11eb-8a17-af2f82587bba.png)
